### PR TITLE
[feat] 백엔드 API 프록시 라우트 구현 및 토큰 자동 갱신 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # Dependencies
-node_modules
+node_modules/
 .pnp
 .pnp.js
 

--- a/client/user/src/app/(nonRoot)/(auth)/login/_components/LoginForm.tsx
+++ b/client/user/src/app/(nonRoot)/(auth)/login/_components/LoginForm.tsx
@@ -3,7 +3,6 @@
 import { useMutation } from '@tanstack/react-query'
 import { login } from '@tookscan/api'
 import { Button, ConsentLabel, InputField } from '@tookscan/components'
-import { ENV } from '@tookscan/config'
 import { useAuth } from '@tookscan/hooks'
 import type { ErrorRes, LoginRes } from '@tookscan/types'
 import { deleteCookie, devConsole, getCookie, setCookie } from '@tookscan/utils'
@@ -38,11 +37,6 @@ export const LoginForm = () => {
     mutationFn: () => login(credentials.id, credentials.password),
     onSuccess: (data: LoginRes) => {
       if (data.success && !data.error) {
-        devConsole.log('로그인 성공:', data)
-        if (ENV.IS_DEV) {
-          setCookie('access_token', data.data.access_token, 1)
-          setCookie('refresh_token', data.data.refresh_token, 1)
-        }
         if (authPreference.saveId) {
           setCookie('serial_id', credentials.id, 1)
         } else {

--- a/client/user/src/app/(nonRoot)/(auth)/login/_components/SocialLogin.tsx
+++ b/client/user/src/app/(nonRoot)/(auth)/login/_components/SocialLogin.tsx
@@ -6,12 +6,10 @@ import Image from 'next/image'
 import Link from 'next/link'
 
 const SocialLogin = () => {
-  const OAUTH_BASE_URL = process.env.NEXT_PUBLIC_PREFIX_URL
-    ? `${process.env.NEXT_PUBLIC_PREFIX_URL}/oauth2/authorization`
+  const OAUTH_BASE_URL = process.env.NEXT_PUBLIC_API_URL
+    ? `${process.env.NEXT_PUBLIC_API_URL}/oauth2/authorization`
     : (() => {
-        throw new Error(
-          'NEXT_PUBLIC_PREFIX_URL 환경 변수가 설정되지 않았습니다.'
-        )
+        throw new Error('NEXT_PUBLIC_API_URL 환경 변수가 설정되지 않았습니다.')
       })()
 
   return (

--- a/client/user/src/app/(nonRoot)/profile/layout.tsx
+++ b/client/user/src/app/(nonRoot)/profile/layout.tsx
@@ -9,13 +9,10 @@ import type { MenuItem } from '@tookscan/components'
 import { Tab } from '@tookscan/components'
 
 const profileItems: MenuItem[] = [
+  { label: '주문 내역 조회', link: '/profile/order' },
   { label: '개인정보 수정', link: '/profile/edit/info' },
   { label: '비밀번호 변경', link: '/profile/edit/password' },
-  { label: '주문 내역 조회', link: '/profile/order' },
 ]
-
-
-
 
 const ProfileLayout = ({ children }: LayoutProps) => {
   const pathname = usePathname()
@@ -48,7 +45,7 @@ const ProfileLayout = ({ children }: LayoutProps) => {
             </div>
             {/*  선택된 라벨*/}
             {currentLabel && (
-              <h2 className="title2 mt-[1rem] self-start">{currentLabel}</h2>
+              <h2 className="mt-[1rem] self-start title2">{currentLabel}</h2>
             )}
           </div>
 

--- a/client/user/src/app/(nonRoot)/profile/page.tsx
+++ b/client/user/src/app/(nonRoot)/profile/page.tsx
@@ -1,10 +1,9 @@
-import React from 'react'
 import { AutoRedirect } from '@tookscan/components'
 
 const page = () => {
   return (
     <div>
-      <AutoRedirect to="/profile/edit/info" />
+      <AutoRedirect to="/profile/order" />
     </div>
   )
 }

--- a/client/user/src/app/api/proxy/[...slug]/route.ts
+++ b/client/user/src/app/api/proxy/[...slug]/route.ts
@@ -1,21 +1,23 @@
 import { kyInstance } from '@tookscan/config'
+import type { ReissueTokenRes } from '@tookscan/types'
 import { devConsole } from '@tookscan/utils'
 import ky from 'ky'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
 const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_URL
+const MAX_RETRY = 3 // ✅ 최대 3번 재발급 시도
 
 /**
  * 백엔드 API 프록시 요청을 처리하는 함수
  * - 요청을 백엔드로 전달하고 응답을 클라이언트로 반환
- * - Access Token이 만료된 경우 Refresh Token으로 자동 갱신
+ * - Access Token이 만료된 경우 최대 3번까지 Refresh Token으로 자동 갱신
  */
-async function proxyRequest(request: Request, slug: string[]) {
+async function proxyRequest(request: Request, slug: string[], retryCount = 0) {
   // ✅ 클라이언트의 HttpOnly 쿠키에서 Access Token, Refresh Token 가져오기
   const cookieStore = await cookies()
   let accessToken = cookieStore.get('access_token')?.value
-  const refreshToken = cookieStore.get('refresh_token')?.value
+  let refreshToken = cookieStore.get('refresh_token')?.value
 
   // ✅ 백엔드 API 경로 생성 (ex: /api/v1/auth/login)
   const backendPath = slug.join('/')
@@ -34,58 +36,78 @@ async function proxyRequest(request: Request, slug: string[]) {
   }
 
   // ✅ 백엔드로 API 요청 전송
-  let backendResponse = await kyInstance(url.toString(), {
-    method: request.method,
-    headers,
-    body:
-      request.method !== 'GET' && request.method !== 'HEAD'
-        ? await request.text()
-        : undefined,
-  })
+  let backendResponse: Response
+  try {
+    backendResponse = await kyInstance(url.toString(), {
+      method: request.method,
+      headers,
+      body:
+        request.method !== 'GET' && request.method !== 'HEAD'
+          ? await request.text()
+          : undefined,
+    })
+  } catch (error) {
+    devConsole.error('🚨 API 요청 중 네트워크 오류 발생:', error)
+    if (typeof error === 'object' && error !== null && 'error' in error) {
+      const err = error as { error?: { code: number } }
+      if (err.error?.code === 40101 || err.error?.code === 40001) {
+        devConsole.log('🔒 Access Token expired. Attempting refresh...')
+        if (retryCount >= MAX_RETRY) {
+          devConsole.log(
+            '❌ Maximum token refresh attempts reached. Logging out...'
+          )
 
-  // ✅ Access Token이 만료된 경우 Refresh Token을 이용해 재발급 후 재요청
-  if (backendResponse.status === 401 && refreshToken) {
-    devConsole.log('🔄 Access Token expired. Trying to refresh token...')
-    const refreshResponse = await ky.post(
-      `${BACKEND_API_URL}/auth/reissue/token`,
-      {
-        headers: {
-          Authorization: `Bearer ${refreshToken}`,
-        },
+          // ✅ 쿠키 초기화 (토큰 삭제)
+          cookieStore.delete('access_token')
+          cookieStore.delete('refresh_token')
+
+          // ✅ 로그인 페이지로 리디렉트
+          return NextResponse.redirect(new URL('/login', request.url))
+        }
+
+        devConsole.log(
+          `🔄 Access Token expired. Attempting refresh... (${retryCount + 1}/${MAX_RETRY})`
+        )
+
+        const reissueToken = async (): Promise<ReissueTokenRes> => {
+          const response = await ky.post(
+            `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/reissue/token`,
+            {
+              headers: {
+                Authorization: `Bearer ${refreshToken}`,
+              },
+            }
+          )
+
+          return response.json()
+        }
+
+        const refreshResponse = await reissueToken()
+
+        if (refreshResponse.success) {
+          accessToken = refreshResponse.data.access_token
+          refreshToken = refreshResponse.data.refresh_token
+          devConsole.log('✅ Access Token refreshed successfully')
+
+          // ✅ 새 Access Token & Refresh Token을 쿠키에 저장
+          cookieStore.set('access_token', accessToken, {
+            httpOnly: true,
+            secure: true,
+            path: '/',
+          })
+          cookieStore.set('refresh_token', refreshToken, {
+            httpOnly: true,
+            secure: true,
+            path: '/',
+          })
+
+          // ✅ 새로운 Access Token으로 백엔드 API 재요청 (재귀 호출)
+          headers.set('Authorization', `Bearer ${accessToken}`)
+          return proxyRequest(request, slug, retryCount + 1)
+        }
       }
-    )
-
-    if (refreshResponse.ok) {
-      const refreshData = (await refreshResponse.json()) as {
-        access_token: string
-      }
-      accessToken = refreshData.access_token
-      devConsole.log('✅ Access Token refreshed successfully')
-
-      // ✅ 새 Access Token을 쿠키에 저장 (보안 설정 포함)
-      const response = NextResponse.json(
-        { message: 'Token refreshed, retrying request' },
-        { status: 200 }
-      )
-      if (accessToken) {
-        response.cookies.set('access_token', accessToken, {
-          httpOnly: true, // XSS 방지를 위해 클라이언트에서 접근 불가
-          secure: true, // HTTPS 환경에서만 전송
-          path: '/',
-        })
-      }
-
-      // ✅ 새로운 Access Token으로 백엔드 API 재요청
-      headers.set('Authorization', `Bearer ${accessToken}`)
-      backendResponse = await kyInstance(url.toString(), {
-        method: request.method,
-        headers,
-        body:
-          request.method !== 'GET' && request.method !== 'HEAD'
-            ? await request.text()
-            : undefined,
-      })
     }
+    return NextResponse.json({ error: '네트워크 오류 발생' }, { status: 502 })
   }
 
   // ✅ 응답이 JSON인지 확인 후 변환 (예외 처리 포함)
@@ -94,9 +116,13 @@ async function proxyRequest(request: Request, slug: string[]) {
     data = await backendResponse.json()
   } catch (error) {
     devConsole.error('⚠️ Error parsing JSON response:', error)
-    data = await backendResponse.text()
+    return NextResponse.json(
+      { error: '응답 데이터 파싱 오류' },
+      { status: backendResponse.status } // 원래 상태 코드 유지
+    )
   }
 
+  // ✅ 백엔드 응답 상태 코드 유지하여 클라이언트에 반환
   const response = NextResponse.json(data, { status: backendResponse.status })
 
   // ✅ 백엔드의 Set-Cookie 헤더가 있을 경우 클라이언트로 전달

--- a/client/user/src/app/api/proxy/[...slug]/route.ts
+++ b/client/user/src/app/api/proxy/[...slug]/route.ts
@@ -1,4 +1,4 @@
-import { proxyInstance } from '@tookscan/config'
+import { kyInstance } from '@tookscan/config'
 import { devConsole } from '@tookscan/utils'
 import ky from 'ky'
 import { cookies } from 'next/headers'
@@ -34,7 +34,7 @@ async function proxyRequest(request: Request, slug: string[]) {
   }
 
   // ✅ 백엔드로 API 요청 전송
-  let backendResponse = await proxyInstance(url.toString(), {
+  let backendResponse = await kyInstance(url.toString(), {
     method: request.method,
     headers,
     body:
@@ -77,7 +77,7 @@ async function proxyRequest(request: Request, slug: string[]) {
 
       // ✅ 새로운 Access Token으로 백엔드 API 재요청
       headers.set('Authorization', `Bearer ${accessToken}`)
-      backendResponse = await proxyInstance(url.toString(), {
+      backendResponse = await kyInstance(url.toString(), {
         method: request.method,
         headers,
         body:

--- a/client/user/src/app/api/proxy/[...slug]/route.ts
+++ b/client/user/src/app/api/proxy/[...slug]/route.ts
@@ -46,12 +46,14 @@ async function proxyRequest(request: Request, slug: string[]) {
   // ✅ Access Token이 만료된 경우 Refresh Token을 이용해 재발급 후 재요청
   if (backendResponse.status === 401 && refreshToken) {
     devConsole.log('🔄 Access Token expired. Trying to refresh token...')
-    const refreshResponse = await ky(`${BACKEND_API_URL}/auth/refresh`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${refreshToken}`,
-      },
-    })
+    const refreshResponse = await ky.post(
+      `${BACKEND_API_URL}/auth/reissue/token`,
+      {
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+        },
+      }
+    )
 
     if (refreshResponse.ok) {
       const refreshData = (await refreshResponse.json()) as {

--- a/client/user/src/app/api/proxy/[...slug]/route.ts
+++ b/client/user/src/app/api/proxy/[...slug]/route.ts
@@ -1,30 +1,40 @@
-// TODO : 프록시 API 라우트를 작성 마저 완성 필요
-
-import { httpInstance } from '@tookscan/config'
+import { proxyInstance } from '@tookscan/config'
+import { devConsole } from '@tookscan/utils'
+import ky from 'ky'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
-const BACKEND_API_URL =
-  process.env.BACKEND_API_URL || 'https://backend.example.com'
+const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_URL
 
+/**
+ * 백엔드 API 프록시 요청을 처리하는 함수
+ * - 요청을 백엔드로 전달하고 응답을 클라이언트로 반환
+ * - Access Token이 만료된 경우 Refresh Token으로 자동 갱신
+ */
 async function proxyRequest(request: Request, slug: string[]) {
+  // ✅ 클라이언트의 HttpOnly 쿠키에서 Access Token, Refresh Token 가져오기
   const cookieStore = await cookies()
-  const accessToken = cookieStore.get('accesstoken')?.value
+  let accessToken = cookieStore.get('access_token')?.value
+  const refreshToken = cookieStore.get('refresh_token')?.value
 
+  // ✅ 백엔드 API 경로 생성 (ex: /api/v1/auth/login)
   const backendPath = slug.join('/')
-  const url = new URL(`${BACKEND_API_URL}/${backendPath}`)
+  const url = new URL(`${BACKEND_API_URL}/api/v1/${backendPath}`)
 
+  // ✅ 원래 요청의 쿼리 파라미터 유지
   const requestUrl = new URL(request.url)
   requestUrl.searchParams.forEach((value, key) => {
     url.searchParams.append(key, value)
   })
 
+  // ✅ 요청 헤더 설정
   const headers = new Headers(request.headers)
   if (accessToken) {
     headers.set('Authorization', `Bearer ${accessToken}`)
   }
 
-  const backendResponse = await httpInstance(url.toString(), {
+  // ✅ 백엔드로 API 요청 전송
+  let backendResponse = await proxyInstance(url.toString(), {
     method: request.method,
     headers,
     body:
@@ -33,11 +43,71 @@ async function proxyRequest(request: Request, slug: string[]) {
         : undefined,
   })
 
-  const data = await backendResponse.text()
+  // ✅ Access Token이 만료된 경우 Refresh Token을 이용해 재발급 후 재요청
+  if (backendResponse.status === 401 && refreshToken) {
+    devConsole.log('🔄 Access Token expired. Trying to refresh token...')
+    const refreshResponse = await ky(`${BACKEND_API_URL}/auth/refresh`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+      },
+    })
 
-  return NextResponse.json(JSON.parse(data), { status: backendResponse.status })
+    if (refreshResponse.ok) {
+      const refreshData = (await refreshResponse.json()) as {
+        access_token: string
+      }
+      accessToken = refreshData.access_token
+      devConsole.log('✅ Access Token refreshed successfully')
+
+      // ✅ 새 Access Token을 쿠키에 저장 (보안 설정 포함)
+      const response = NextResponse.json(
+        { message: 'Token refreshed, retrying request' },
+        { status: 200 }
+      )
+      if (accessToken) {
+        response.cookies.set('access_token', accessToken, {
+          httpOnly: true, // XSS 방지를 위해 클라이언트에서 접근 불가
+          secure: true, // HTTPS 환경에서만 전송
+          path: '/',
+        })
+      }
+
+      // ✅ 새로운 Access Token으로 백엔드 API 재요청
+      headers.set('Authorization', `Bearer ${accessToken}`)
+      backendResponse = await proxyInstance(url.toString(), {
+        method: request.method,
+        headers,
+        body:
+          request.method !== 'GET' && request.method !== 'HEAD'
+            ? await request.text()
+            : undefined,
+      })
+    }
+  }
+
+  // ✅ 응답이 JSON인지 확인 후 변환 (예외 처리 포함)
+  let data
+  try {
+    data = await backendResponse.json()
+  } catch (error) {
+    devConsole.error('⚠️ Error parsing JSON response:', error)
+    data = await backendResponse.text()
+  }
+
+  const response = NextResponse.json(data, { status: backendResponse.status })
+
+  // ✅ 백엔드의 Set-Cookie 헤더가 있을 경우 클라이언트로 전달
+  backendResponse.headers.forEach((value, key) => {
+    if (key.toLowerCase().includes('set-cookie')) {
+      response.headers.set(key, value)
+    }
+  })
+
+  return response
 }
 
+// ✅ HTTP 메서드별 프록시 핸들러 (GET, POST, PUT, DELETE, PATCH)
 export async function GET(
   request: Request,
   { params }: { params: { slug: string[] } }
@@ -60,6 +130,13 @@ export async function PUT(
 }
 
 export async function DELETE(
+  request: Request,
+  { params }: { params: { slug: string[] } }
+) {
+  return proxyRequest(request, params.slug)
+}
+
+export async function PATCH(
   request: Request,
   { params }: { params: { slug: string[] } }
 ) {

--- a/client/user/src/app/api/proxy/auth/login/route.ts
+++ b/client/user/src/app/api/proxy/auth/login/route.ts
@@ -1,4 +1,4 @@
-import { proxyInstance } from '@tookscan/config'
+import { kyInstance } from '@tookscan/config'
 import type { LoginRes } from '@tookscan/types'
 import { NextResponse } from 'next/server'
 
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
     }
 
     // ✅ 백엔드 서버로 로그인 요청 전송
-    const backendResponse = await proxyInstance(url, {
+    const backendResponse = await kyInstance(url, {
       method: 'POST',
       body: formData,
     })

--- a/client/user/src/app/api/proxy/auth/login/route.ts
+++ b/client/user/src/app/api/proxy/auth/login/route.ts
@@ -1,0 +1,76 @@
+import { proxyInstance } from '@tookscan/config'
+import type { LoginRes } from '@tookscan/types'
+import { NextResponse } from 'next/server'
+
+const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_URL
+
+export async function POST(request: Request) {
+  try {
+    const url = `${BACKEND_API_URL}/api/v1/auth/login`
+    const formData = new FormData()
+
+    // ✅ 요청의 Content-Type 확인 후 JSON or FormData 변환
+    const contentType = request.headers.get('content-type')
+
+    if (contentType?.includes('application/json')) {
+      // JSON 요청을 받아 FormData로 변환
+      const requestBody = await request.json()
+      Object.entries(requestBody).forEach(([key, value]) => {
+        formData.append(key, value as string)
+      })
+    } else {
+      // 이미 FormData 형태로 요청이 온 경우 그대로 사용
+      const requestFormData = await request.formData()
+      requestFormData.forEach((value, key) => {
+        formData.append(key, value)
+      })
+    }
+
+    // ✅ 백엔드 서버로 로그인 요청 전송
+    const backendResponse = await proxyInstance(url, {
+      method: 'POST',
+      body: formData,
+    })
+
+    // ✅ 백엔드 응답을 LoginRes 타입으로 파싱
+    const data: LoginRes = await backendResponse.json()
+
+    // ✅ 백엔드 응답에서 Access Token과 Refresh Token 추출
+    const accessToken = data?.data?.access_token
+    const refreshToken = data?.data?.refresh_token
+
+    if (!accessToken || !refreshToken) {
+      // 토큰이 없으면 400 에러 반환
+      return NextResponse.json(
+        { error: '토큰이 포함되지 않은 응답입니다.' },
+        { status: 400 }
+      )
+    }
+
+    // ✅ HttpOnly 쿠키로 Access Token 및 Refresh Token 설정 (보안 강화)
+    const response = NextResponse.json(data, { status: backendResponse.status })
+
+    response.cookies.set('access_token', accessToken, {
+      httpOnly: true, // 클라이언트에서 접근 불가 (XSS 공격 방지)
+      secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 HTTPS 필수
+      sameSite: 'strict', // CSRF 방지
+      path: '/', // 모든 페이지에서 쿠키 사용 가능
+    })
+
+    response.cookies.set('refresh_token', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      path: '/',
+    })
+
+    return response
+  } catch (error) {
+    // ❌ 예외 발생 시 500 에러 응답
+    console.error('❌ Error in /api/proxy/auth/login:', error)
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    )
+  }
+}

--- a/client/user/src/app/api/proxy/auth/login/route.ts
+++ b/client/user/src/app/api/proxy/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { kyInstance } from '@tookscan/config'
 import type { LoginRes } from '@tookscan/types'
+import { cookieOptions } from '@tookscan/utils'
 import { NextResponse } from 'next/server'
 
 const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_URL
@@ -50,19 +51,9 @@ export async function POST(request: Request) {
     // ✅ HttpOnly 쿠키로 Access Token 및 Refresh Token 설정 (보안 강화)
     const response = NextResponse.json(data, { status: backendResponse.status })
 
-    response.cookies.set('access_token', accessToken, {
-      httpOnly: true, // 클라이언트에서 접근 불가 (XSS 공격 방지)
-      secure: process.env.NODE_ENV === 'production', // 프로덕션에서는 HTTPS 필수
-      sameSite: 'strict', // CSRF 방지
-      path: '/', // 모든 페이지에서 쿠키 사용 가능
-    })
+    response.cookies.set('access_token', accessToken, cookieOptions(3600))
 
-    response.cookies.set('refresh_token', refreshToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
-      path: '/',
-    })
+    response.cookies.set('refresh_token', refreshToken, cookieOptions(604800))
 
     return response
   } catch (error) {

--- a/client/user/src/app/api/proxy/auth/logout/route.ts
+++ b/client/user/src/app/api/proxy/auth/logout/route.ts
@@ -1,4 +1,5 @@
 import { kyInstance } from '@tookscan/config'
+import { cookieOptions } from '@tookscan/utils'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
@@ -35,21 +36,8 @@ export async function POST() {
         { status: 200 }
       )
 
-      response.cookies.set('access_token', '', {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        path: '/',
-        maxAge: 0, // 즉시 만료
-      })
-
-      response.cookies.set('refresh_token', '', {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
-        path: '/',
-        maxAge: 0, // 즉시 만료
-      })
+      response.cookies.set('access_token', '', cookieOptions(0))
+      response.cookies.set('refresh_token', '', cookieOptions(0))
 
       return response
     }

--- a/client/user/src/app/api/proxy/auth/logout/route.ts
+++ b/client/user/src/app/api/proxy/auth/logout/route.ts
@@ -1,4 +1,4 @@
-import { proxyInstance } from '@tookscan/config'
+import { kyInstance } from '@tookscan/config'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
@@ -19,7 +19,7 @@ export async function POST() {
     }
 
     // ✅ 백엔드로 로그아웃 요청 전송
-    const backendResponse = await proxyInstance(url, {
+    const backendResponse = await kyInstance(url, {
       method: 'POST',
       headers,
     })

--- a/client/user/src/app/api/proxy/auth/logout/route.ts
+++ b/client/user/src/app/api/proxy/auth/logout/route.ts
@@ -1,0 +1,66 @@
+import { proxyInstance } from '@tookscan/config'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_URL
+
+export async function POST() {
+  try {
+    const url = `${BACKEND_API_URL}/api/v1/auth/logout`
+
+    // ✅ 클라이언트의 HttpOnly 쿠키에서 Access Token 가져오기
+    const cookieStore = await cookies()
+    const accessToken = cookieStore.get('access_token')?.value
+
+    // ✅ 요청 헤더 설정 (Access Token 포함)
+    const headers: HeadersInit = {}
+    if (accessToken) {
+      headers['Authorization'] = `Bearer ${accessToken}`
+    }
+
+    // ✅ 백엔드로 로그아웃 요청 전송
+    const backendResponse = await proxyInstance(url, {
+      method: 'POST',
+      headers,
+    })
+
+    // ✅ 응답 데이터 변환
+    const data = await backendResponse.json()
+
+    // ✅ 로그아웃 성공 시 쿠키 삭제 (HttpOnly 쿠키 만료)
+    if (backendResponse.ok) {
+      console.log('✅ 로그아웃 성공, 쿠키 삭제 중...')
+      const response = NextResponse.json(
+        { message: '로그아웃 완료' },
+        { status: 200 }
+      )
+
+      response.cookies.set('access_token', '', {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        path: '/',
+        maxAge: 0, // 즉시 만료
+      })
+
+      response.cookies.set('refresh_token', '', {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        path: '/',
+        maxAge: 0, // 즉시 만료
+      })
+
+      return response
+    }
+
+    // ❌ 백엔드 로그아웃 실패 시 오류 반환
+    return NextResponse.json(data, { status: backendResponse.status })
+  } catch (error) {
+    console.error('❌ Error in /api/proxy/auth/logout:', error)
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    )
+  }
+}

--- a/client/user/src/components/Header/ClientHeader.tsx
+++ b/client/user/src/components/Header/ClientHeader.tsx
@@ -4,7 +4,6 @@ import { useMutation } from '@tanstack/react-query'
 import { logout } from '@tookscan/api'
 import { Icon } from '@tookscan/components'
 import { useAuth, useToast } from '@tookscan/hooks'
-import { deleteCookie } from '@tookscan/utils'
 import clsx from 'clsx'
 import Link from 'next/link'
 
@@ -20,8 +19,6 @@ export const ClientHeader = () => {
     mutationKey: ['logout'],
     mutationFn: logout,
     onSuccess: () => {
-      deleteCookie('access_token')
-      deleteCookie('refresh_token')
       refetchAuth()
       showToast('로그아웃 되었습니다.', 'success', 'check')
     },

--- a/client/user/src/components/Header/ClientHeader.tsx
+++ b/client/user/src/components/Header/ClientHeader.tsx
@@ -1,7 +1,10 @@
 'use client'
 
+import { useMutation } from '@tanstack/react-query'
+import { logout } from '@tookscan/api'
 import { Icon } from '@tookscan/components'
-import { useAuth } from '@tookscan/hooks'
+import { useAuth, useToast } from '@tookscan/hooks'
+import { deleteCookie } from '@tookscan/utils'
 import clsx from 'clsx'
 import Link from 'next/link'
 
@@ -10,8 +13,19 @@ export const ClientHeader = () => {
   const textSize = isMobile ? 'text-[12px]' : 'text-[14px]'
   const heightSize = isMobile ? 'h-4' : 'h-[5.625rem]'
 
-  // 초기 서버에서 받은 auth 정보를 상태로 관리 (필요 시 업데이트할 수 있도록)
-  const { username, isLogin } = useAuth()
+  const { username, isLogin, refetchAuth } = useAuth()
+  const { showToast } = useToast()
+
+  const { mutate: logoutMutate } = useMutation({
+    mutationKey: ['logout'],
+    mutationFn: logout,
+    onSuccess: () => {
+      deleteCookie('access_token')
+      deleteCookie('refresh_token')
+      refetchAuth()
+      showToast('로그아웃 되었습니다.', 'success', 'check')
+    },
+  })
 
   return (
     <div className="flex">
@@ -81,9 +95,12 @@ export const ClientHeader = () => {
               <Link href="/profile" className="text-black hover:underline">
                 마이페이지
               </Link>
-              <Link href="/logout" className="text-black hover:underline">
+              <button
+                className="text-black hover:underline"
+                onClick={() => logoutMutate()}
+              >
                 로그아웃
-              </Link>
+              </button>
             </>
           )}
         </div>

--- a/client/user/src/components/Header/Header.tsx
+++ b/client/user/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { AccountType } from '@tookscan/hooks'
+import type { AccountType } from '@tookscan/types'
 import { ClientHeader } from './ClientHeader'
 
 export type AuthResult = {

--- a/client/user/src/middleware.ts
+++ b/client/user/src/middleware.ts
@@ -1,4 +1,5 @@
 import type { UserInfoRes } from '@tookscan/types'
+import { cookieOptions } from '@tookscan/utils'
 import ky from 'ky'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
@@ -49,19 +50,15 @@ export async function middleware(req: NextRequest) {
           if (reissueRes.success) {
             // 새로운 토큰으로 쿠키 업데이트
             const response = NextResponse.next()
-            response.cookies.set('access_token', reissueRes.data.access_token, {
-              httpOnly: true,
-              secure: process.env.NODE_ENV === 'production',
-              path: '/',
-            })
+            response.cookies.set(
+              'access_token',
+              reissueRes.data.access_token,
+              cookieOptions(3600)
+            )
             response.cookies.set(
               'refresh_token',
               reissueRes.data.refresh_token,
-              {
-                httpOnly: true,
-                secure: process.env.NODE_ENV === 'production',
-                path: '/',
-              }
+              cookieOptions()
             )
             // 토큰 재발급 성공 시, middleware에서 바로 다음 단계로 진행
             return response

--- a/client/user/src/middleware.ts
+++ b/client/user/src/middleware.ts
@@ -1,21 +1,51 @@
+import type { UserInfoRes } from '@tookscan/types'
+import ky from 'ky'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-export function middleware(req: NextRequest) {
-  const token = req.cookies.get('auth_token')?.value
+export async function middleware(req: NextRequest) {
+  const accessToken = req.cookies.get('access_token')?.value
 
+  // ✅ 보호된 페이지 목록
   const protectedRoutes = ['/profile']
 
+  // ✅ 로그인되지 않은 사용자는 로그인 페이지로 리디렉트
   if (
     protectedRoutes.some((route) => req.nextUrl.pathname.startsWith(route)) &&
-    !token
+    !accessToken
   ) {
     return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  // ✅ Access Token이 존재하면 userInfo 호출하여 유효성 검사
+  if (accessToken) {
+    try {
+      const data: UserInfoRes = await ky
+        .get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/briefs`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        .json()
+
+      // ✅ 토큰이 유효한지 검사
+      const isValidUser =
+        data?.success && !data?.error && data?.data?.account_type !== 'GUEST'
+
+      if (!isValidUser) {
+        console.log('❌ Invalid User, redirecting to login...')
+        return NextResponse.redirect(new URL('/login', req.url))
+      }
+    } catch (error) {
+      console.error('❌ Error validating user:', error)
+      return NextResponse.redirect(new URL('/login', req.url))
+    }
   }
 
   return NextResponse.next()
 }
 
+// ✅ 적용할 라우트 설정 (로그인 필요 페이지)
 export const config = {
   matcher: ['/profile/:path*'],
 }

--- a/client/user/src/middleware.ts
+++ b/client/user/src/middleware.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('auth_token')?.value
+
+  const protectedRoutes = ['/profile']
+
+  if (
+    protectedRoutes.some((route) => req.nextUrl.pathname.startsWith(route)) &&
+    !token
+  ) {
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/profile/:path*'],
+}

--- a/client/user/src/middleware.ts
+++ b/client/user/src/middleware.ts
@@ -5,11 +5,9 @@ import { NextResponse } from 'next/server'
 
 export async function middleware(req: NextRequest) {
   const accessToken = req.cookies.get('access_token')?.value
-
-  // ✅ 보호된 페이지 목록
+  const refreshToken = req.cookies.get('refresh_token')?.value
   const protectedRoutes = ['/profile']
 
-  // ✅ 로그인되지 않은 사용자는 로그인 페이지로 리디렉트
   if (
     protectedRoutes.some((route) => req.nextUrl.pathname.startsWith(route)) &&
     !accessToken
@@ -17,27 +15,62 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(new URL('/login', req.url))
   }
 
-  // ✅ Access Token이 존재하면 userInfo 호출하여 유효성 검사
+  // Access Token이 있으면 유효성 검사
   if (accessToken) {
     try {
       const data: UserInfoRes = await ky
         .get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/briefs`, {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
+          headers: { Authorization: `Bearer ${accessToken}` },
         })
         .json()
 
-      // ✅ 토큰이 유효한지 검사
       const isValidUser =
         data?.success && !data?.error && data?.data?.account_type !== 'GUEST'
 
       if (!isValidUser) {
-        console.log('❌ Invalid User, redirecting to login...')
-        return NextResponse.redirect(new URL('/login', req.url))
+        throw new Error('Token invalid')
       }
     } catch (error) {
-      console.error('❌ Error validating user:', error)
+      // 토큰 검증 실패 시(예: 만료된 토큰) 재발급 시도
+      if (refreshToken) {
+        try {
+          const reissueRes = await ky
+            .post(
+              `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/reissue/token`,
+              {
+                headers: { Authorization: `Bearer ${refreshToken}` },
+              }
+            )
+            .json<{
+              success: boolean
+              data: { access_token: string; refresh_token: string }
+            }>()
+
+          if (reissueRes.success) {
+            // 새로운 토큰으로 쿠키 업데이트
+            const response = NextResponse.next()
+            response.cookies.set('access_token', reissueRes.data.access_token, {
+              httpOnly: true,
+              secure: process.env.NODE_ENV === 'production',
+              path: '/',
+            })
+            response.cookies.set(
+              'refresh_token',
+              reissueRes.data.refresh_token,
+              {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                path: '/',
+              }
+            )
+            // 토큰 재발급 성공 시, middleware에서 바로 다음 단계로 진행
+            return response
+          }
+        } catch (reissueError) {
+          console.error('❌ Token reissue failed:', reissueError)
+        }
+      }
+      // 재발급 실패 시 /login으로 리디렉션
       return NextResponse.redirect(new URL('/login', req.url))
     }
   }
@@ -45,7 +78,6 @@ export async function middleware(req: NextRequest) {
   return NextResponse.next()
 }
 
-// ✅ 적용할 라우트 설정 (로그인 필요 페이지)
 export const config = {
   matcher: ['/profile/:path*'],
 }

--- a/client/user/tsconfig.json
+++ b/client/user/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": [
+        "src/*"
+      ]
     },
     "allowJs": true,
     "skipLibCheck": true,
@@ -19,8 +21,9 @@
   },
   "include": [
     "src/**/*",
-    ".next/types/**/*.ts",
-    "../../packages/components/**/*"
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/api/auth.ts
+++ b/packages/api/auth.ts
@@ -82,3 +82,7 @@ export const findPassword = async (
 
   return response.json()
 }
+
+export const logout = async () => {
+  await httpInstance.post('auth/logout')
+}

--- a/packages/components/node_modules/@shared/tailwind
+++ b/packages/components/node_modules/@shared/tailwind
@@ -1,1 +1,0 @@
-../../../shared/tailwind

--- a/packages/config/ky.config.ts
+++ b/packages/config/ky.config.ts
@@ -1,22 +1,17 @@
 import ky from 'ky'
-import { ENV } from '../config'
-import { getCookie } from '../utils'
 import { devConsole } from '../utils/devConsole'
 
-const createApiClient = (headers?: Record<string, string>) => {
+const createApiClient = (
+  prefixUrl: string,
+  headers?: Record<string, string>
+) => {
   return ky.create({
-    prefixUrl: `${process.env.NEXT_PUBLIC_PREFIX_URL}/api/v1`,
+    prefixUrl: prefixUrl,
     timeout: 3000,
     headers,
     hooks: {
       beforeRequest: [
         (req) => {
-          if (ENV.IS_DEV) {
-            const accessToken = getCookie('access_token')
-            if (accessToken) {
-              req.headers.set('Authorization', `Bearer ${accessToken}`)
-            }
-          }
           devConsole.log('[Request Config]:', {
             url: req.url,
             method: req.method,
@@ -49,11 +44,10 @@ const createApiClient = (headers?: Record<string, string>) => {
     throwHttpErrors: false,
   })
 }
+const httpInstance = createApiClient(
+  `${process.env.NEXT_PUBLIC_APP_URL}/api/proxy`
+)
 
-const httpInstance = createApiClient({})
+const proxyInstance = createApiClient(``)
 
-const uploadInstance = createApiClient({
-  'Content-Type': 'multipart/form-data',
-})
-
-export { httpInstance, uploadInstance }
+export { httpInstance, proxyInstance }

--- a/packages/config/ky.config.ts
+++ b/packages/config/ky.config.ts
@@ -48,6 +48,6 @@ const httpInstance = createApiClient(
   `${process.env.NEXT_PUBLIC_APP_URL}/api/proxy`
 )
 
-const proxyInstance = createApiClient(``)
+const kyInstance = createApiClient('')
 
-export { httpInstance, proxyInstance }
+export { httpInstance, kyInstance }

--- a/packages/hooks/useAuth.ts
+++ b/packages/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { UserInfoRes } from '@/types'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { userInfo } from '../api'
 
 export type AccountType = 'USER' | 'ADMIN' | 'GUEST'
@@ -13,22 +13,28 @@ export interface AuthState {
 }
 
 export const useAuth = () => {
+  const queryClient = useQueryClient()
+
   const { data, isLoading, error } = useQuery<UserInfoRes>({
     queryKey: ['auth'],
-    queryFn: async () => {
-      const data = await userInfo()
-      return data
-    },
+    queryFn: userInfo,
   })
 
   const isLogin = Boolean(
     data?.data && !error && data.data.account_type !== 'GUEST'
   )
 
+  const refreshAuth = () => {
+    queryClient.invalidateQueries({
+      queryKey: ['auth'],
+    })
+  }
+
   return {
     isLogin,
     username: data?.data.name || 'USER',
     accountType: data?.data.account_type || 'GUEST',
+    refreshAuth,
     isLoading,
     error,
   }

--- a/packages/hooks/useAuth.ts
+++ b/packages/hooks/useAuth.ts
@@ -24,7 +24,7 @@ export const useAuth = () => {
     data?.data && !error && data.data.account_type !== 'GUEST'
   )
 
-  const refreshAuth = () => {
+  const refetchAuth = () => {
     queryClient.invalidateQueries({
       queryKey: ['auth'],
     })
@@ -34,7 +34,7 @@ export const useAuth = () => {
     isLogin,
     username: data?.data.name || 'USER',
     accountType: data?.data.account_type || 'GUEST',
-    refreshAuth,
+    refetchAuth,
     isLoading,
     error,
   }

--- a/packages/hooks/useAuth.ts
+++ b/packages/hooks/useAuth.ts
@@ -1,8 +1,7 @@
 import { UserInfoRes } from '@/types'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { userInfo } from '../api'
-
-export type AccountType = 'USER' | 'ADMIN' | 'GUEST'
+import { AccountType } from '../types'
 
 export interface AuthState {
   isLogin: boolean

--- a/packages/types/api/auth.ts
+++ b/packages/types/api/auth.ts
@@ -1,3 +1,4 @@
+import { AccountType } from '../'
 import type { Common } from '../api'
 
 export type LoginRes = Common<{
@@ -6,7 +7,7 @@ export type LoginRes = Common<{
 }>
 
 export type UserInfoRes = Common<{
-  account_type: 'USER' | 'ADMIN' | 'GUEST'
+  account_type: AccountType
   name: string
 }>
 

--- a/packages/types/api/auth.ts
+++ b/packages/types/api/auth.ts
@@ -25,3 +25,8 @@ export type FindSerialIdRes = Common<{
 export type FindPasswordRes = Common<{
   temporary_password: string
 }>
+
+export type ReissueTokenRes = Common<{
+  access_token: string
+  refresh_token: string
+}>

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -1,0 +1,1 @@
+export type AccountType = 'USER' | 'ADMIN' | 'GUEST'

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,1 +1,2 @@
 export * from './api'
+export * from './common'

--- a/packages/utils/auth.ts
+++ b/packages/utils/auth.ts
@@ -1,19 +1,20 @@
-/**
- * @deprecated 이 함수는 더 이상 사용되지 않습니다. 대신 useAuth 훅을 사용해주세요.
- *
- * 참고: useAuth를 사용하여 서버 컴포넌트를 클라이언트 컴포넌트로 변경해야 하는 경우,
- * TODO 주석으로 표시해 주세요.
- */
-
 import { userInfo } from '../api'
+import { AccountType } from '../types'
 
-export const auth = async () => {
+export type AuthInfo = {
+  isLogin: boolean
+  username: string
+  accountType: AccountType
+}
+
+export const auth = async (): Promise<AuthInfo> => {
   const data = await userInfo()
-  const isLogin: boolean = Boolean(data && data.success && !data.error)
 
   return {
-    isLogin,
-    username: data && data.data ? data.data.name : '',
-    accountType: data && data.data ? data.data.account_type : 'USER',
+    isLogin: Boolean(
+      data?.success && !data?.error && data?.data?.account_type !== 'GUEST'
+    ),
+    username: data?.data?.name || '',
+    accountType: data?.data?.account_type || 'GUEST',
   }
 }

--- a/packages/utils/cookies.ts
+++ b/packages/utils/cookies.ts
@@ -69,3 +69,12 @@ export const resetCookies = (): void => {
     deleteCookie(cookieName)
   }
 }
+
+export const cookieOptions = (time?: number) => ({
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'strict' as const,
+  path: '/',
+  maxAge: time,
+  domain: process.env.NEXT_PUBLIC_APP_URL,
+})


### PR DESCRIPTION
## 📝 작업 내용

### (🔥 ENV업데이트 있습니다!!! 🔥)

이번 PR에서는 백엔드 API 프록시 라우트를 구현하고, Access Token 만료 시 Refresh Token을 사용해 자동으로 토큰을 갱신하는 기능을 추가했습니다.  
주요 변경 사항은 아래와 같습니다:

- **API 프록시 라우트 구현:**  
  모든 HTTP 메서드(GET, POST, PUT, DELETE, PATCH)에 대해 백엔드 API 요청을 프록시 처리하도록 구현했습니다.  
  - 요청 경로와 쿼리 파라미터를 유지하며, 백엔드 API 경로(`/api/v1/...`)로 전달합니다.
  - 이제 백엔드 로그를 next.js 서버의 로그로 봐야합니다.

- **토큰 자동 갱신 기능 추가:**  
  - Access Token이 만료되어 (401 또는 403 응답) 재발급이 필요한 경우, 최대 3회까지 자동으로 reissueToken API를 호출하여 토큰을 갱신합니다.
  - 재발급 성공 시, 새로운 Access Token과 Refresh Token을 HttpOnly 쿠키에 저장하고, 갱신된 토큰으로 요청을 재시도합니다.
  - 최대 재발급 시도 횟수를 초과하면, 쿠키를 초기화한 후 `/login`으로 리디렉션하여 로그아웃 처리를 합니다.

- **Refresh Token을 헤더에 포함:**  
  토큰 재발급 API 호출 시, Refresh Token을 `Authorization: Bearer <refresh_token>` 헤더에 포함하도록 수정했습니다.

- **코드 정리:**  
  - 불필요한 `await` 제거 및 `context.params` 처리를 개선했습니다.
  - 에러 발생 시 원래의 응답 상태 코드(예: 401, 403 등)를 유지해 클라이언트가 정확한 에러를 인지할 수 있도록 했습니다.

- 로그아웃 기능 구현

- useAuth 훅 수정
  - 사용자 상태를 강제로 refetch 하는 기능을 추가했습니다.

## 스크린샷 (선택)

*작업 결과를 확인할 수 있는 스크린샷을 첨부할 수 있습니다.*

## 💬 리뷰 요구사항

- 토큰 재발급 로직과 재귀 호출 방식에 대해 검토 부탁드립니다.
- API 프록시 및 토큰 관리 관련 코드의 가독성과 명칭 개선 여지가 있는지 의견 부탁드립니다.
- 에러 처리 및 상태 코드 반환 방식이 적절한지 확인해 주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 프로필 메뉴에 ‘주문 내역 조회’ 항목이 추가되고, 프로필 페이지의 자동 리디렉션 대상이 주문 내역 페이지로 변경되어 사용자 접근성이 개선되었습니다.
  - 로그아웃 버튼 동작 시 성공 토스트 메시지가 표시되어, 로그아웃 후 상태 변화가 명확해졌습니다.
  - 로그인 요청 처리 로직이 개선되어, 보안 강화 및 사용자 인증 과정이 간소화되었습니다.

- **Refactor**
  - 로그인 및 인증 처리 로직이 개선되어, 보다 안정적인 세션 관리와 사용자 경험이 제공됩니다.
  - API 클라이언트 생성 과정이 간소화되어, 유연성과 유지보수성이 향상되었습니다.

- **Chores**
  - 내부 구성 및 설정 파일이 업데이트되어 시스템 안정성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->