### PR TITLE
design: 404페이지, 서버점검 페이지 구현

### DIFF
--- a/client/user/src/app/layout.tsx
+++ b/client/user/src/app/layout.tsx
@@ -1,12 +1,28 @@
 'use server'
 
 import { CommonLayout, Meta, Providers } from '@/app/_components'
+import MaintenancePage from '@/app/maintenance/maintenance'
 import { GoogleTagManagerNoScript } from '@/components'
 import type { LayoutProps } from '@/types/common'
 import '@tookscan/styles/globals.css'
 import '@tookscan/styles/reset.css'
 
 const RootLayout = async ({ children }: LayoutProps) => {
+  const isMaintenanceMode = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true'
+
+  if (isMaintenanceMode) {
+    return (
+      <html lang="ko">
+        <Meta />
+        <body>
+          <GoogleTagManagerNoScript />
+          <Providers>
+            <MaintenancePage />
+          </Providers>
+        </body>
+      </html>
+    )
+  }
   return (
     <html lang="ko">
       <Meta />

--- a/client/user/src/app/maintenance/maintenance.tsx
+++ b/client/user/src/app/maintenance/maintenance.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { Icon } from '@tookscan/components/ui'
+
+const MaintenancePage = () => {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-100 px-4 text-center">
+      <Icon
+        id="logo"
+        width={300}
+        height={132}
+        className="mb-6 text-blue-primary"
+      />
+
+      <h1 className="text-4xl font-bold text-gray-800">서버 점검 중입니다</h1>
+      <p className="mt-4 text-lg text-gray-600">
+        현재 점검이 진행 중입니다. <br />
+        보다 나은 서비스를 제공하기 위해 노력하고 있습니다.
+      </p>
+      <p className="text-md mt-2 text-gray-500">잠시 후 다시 접속해주세요.</p>
+    </div>
+  )
+}
+
+export default MaintenancePage

--- a/client/user/src/app/not-found.tsx
+++ b/client/user/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { CommonLayout } from '@/app/_components'
+import { Icon } from '@tookscan/components/ui'
+
+const NotFoundPage = () => {
+  return (
+    <CommonLayout>
+      <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+        <Icon
+          id="logo"
+          width={300}
+          height={132}
+          className="mb-6 text-blue-primary"
+        />
+
+        <h1 className="text-4xl font-bold text-gray-800">
+          404 - 페이지를 찾을 수 없습니다
+        </h1>
+        <p className="mt-4 text-lg text-gray-600">
+          요청하신 페이지가 존재하지 않습니다.
+        </p>
+      </div>
+    </CommonLayout>
+  )
+}
+
+export default NotFoundPage


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #102 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
404 오류 페이지를 완성했습니다.
디자인이 따로 없어서 로고와 보편적인 텍스트 메시지로 완성했습니다.
서버 점검 페이지를 완성했습니다.
서버 점검 여부는 .env 페이지에서 boolean 값으로 설정할 수 있습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 유지 관리 모드 활성 시, 사용자에게 전용 유지 관리 페이지가 표시되어 서버 점검 중임을 명확히 안내합니다.
	- 존재하지 않는 페이지 접근 시, 사용자에게 친숙한 404 오류 페이지가 제공되어 적절한 안내를 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->